### PR TITLE
22308 clean up local storage access

### DIFF
--- a/app/components/search/ResultsBox.vue
+++ b/app/components/search/ResultsBox.vue
@@ -236,7 +236,7 @@ function checkIfCustomSubmitDateChosen(option: any) {
 
 // Store filter status into local storage
 function setFilterStatus(column: string, option: string) {
-  window.localStorage.setItem(column, option);
+  window.localStorage.setItem(column, JSON.stringify(option));
 }
 
 function onDateDialogSubmit(startDate: string, endDate: string) {

--- a/app/enums/filter-dropdowns.ts
+++ b/app/enums/filter-dropdowns.ts
@@ -39,28 +39,10 @@ enum LastUpdate {
   Days30 = '30 days'
 }
 
-enum FilterKey {
-  ConsentRequired = 'consentRequired',
-  Priority = 'priority',
-  ClientNotification = 'clientNotification',
-  Submitted = 'submitted',
-  LastUpdate = 'lastUpdate',
-}
-
-const filterTypeMap = {
-  [FilterKey.ConsentRequired]: ConsentRequired.All,
-  [FilterKey.Priority]: Priority.All,
-  [FilterKey.ClientNotification]: ClientNotification.All,
-  [FilterKey.Submitted]: Submitted.All,
-  [FilterKey.LastUpdate]: LastUpdate.All,
-}
-
 export {
   ConsentRequired,
   Priority,
   ClientNotification,
   Submitted,
   LastUpdate,
-  FilterKey,
-  filterTypeMap
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "name-examination",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "private": true,
   "scripts": {
     "build": "nuxt generate",

--- a/app/store/search.ts
+++ b/app/store/search.ts
@@ -6,9 +6,7 @@ import {
   ConsentRequired,
   LastUpdate,
   Priority,
-  Submitted,
-  FilterKey,
-  filterTypeMap
+  Submitted
 } from '~/enums/filter-dropdowns'
 import { getFormattedDateWithTime } from '~/util/date'
 import { getNamexObject, getNamexApiUrl } from '~/util/namex-api'
@@ -25,11 +23,11 @@ export const defaultFilters = (): Filters => {
     [SearchColumns.Names]: '',
     [SearchColumns.ApplicantFirstName]: '',
     [SearchColumns.ApplicantLastName]: '',
-    [SearchColumns.ConsentRequired]: getLocalStorageValue(SearchColumns.ConsentRequired, filterTypeMap[FilterKey.ConsentRequired]),
-    [SearchColumns.Priority]: getLocalStorageValue(SearchColumns.Priority, filterTypeMap[FilterKey.Priority]),
-    [SearchColumns.ClientNotification]: getLocalStorageValue(SearchColumns.ClientNotification, filterTypeMap[FilterKey.ClientNotification]),
-    [SearchColumns.Submitted]: getLocalStorageValue(SearchColumns.Submitted, filterTypeMap[FilterKey.Submitted]),
-    [SearchColumns.LastUpdate]: getLocalStorageValue(SearchColumns.LastUpdate, filterTypeMap[FilterKey.LastUpdate]),
+    [SearchColumns.ConsentRequired]: getLocalStorageValue(SearchColumns.ConsentRequired, ConsentRequired.All),
+    [SearchColumns.Priority]: getLocalStorageValue(SearchColumns.Priority, Priority.All),
+    [SearchColumns.ClientNotification]: getLocalStorageValue(SearchColumns.ClientNotification, ClientNotification.All),
+    [SearchColumns.Submitted]: getLocalStorageValue(SearchColumns.Submitted, Submitted.All),
+    [SearchColumns.LastUpdate]: getLocalStorageValue(SearchColumns.LastUpdate, LastUpdate.All),
   }
 }
 

--- a/app/util/index.ts
+++ b/app/util/index.ts
@@ -149,16 +149,11 @@ export const getLocalStorageValue = <T>(key: string, defaultValue: T): T => {
     return defaultValue
   }
   try {
-    // Try to parse as JSON first
+    // Try to parse into the correct type
     const item = JSON.parse(storedValue) as T
     return item
   } catch (error) {
-    // If parsing fails and the type is string, return the stored value directly
-    if (typeof defaultValue === 'string') {
-      return storedValue as unknown as T
-    } else {
       window.localStorage.setItem(key, JSON.stringify(defaultValue))
       return defaultValue
     }
-  }
 }


### PR DESCRIPTION
*Issue #:* 22308
https://app.zenhub.com/workspaces/names-team-board-new-655554cbddd49510027dad2e/issues/gh/bcgov/entity/22308

*Description of changes:*
Cleaned up code I added in my last PR which was made quickly as a hot-fix. [bcgov/name-examination#1485](https://github.com/bcgov/name-examination/pull/1485).

The enums were only used for mapping so got rid of them and added the default values directly when initializing the store. 

Also stringified the search column values before storing in local storage so it is consistent with how everything else is stored in local storage. This made the catch block if clause when retrieving values from local storage redundant so that was removed as well. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
